### PR TITLE
Update modelicalanguage.html

### DIFF
--- a/modelicalanguage.html
+++ b/modelicalanguage.html
@@ -975,7 +975,7 @@ about 1600 model components and 1350 functions from many domains.</p>
 <p>
 <strong>Modelica Simulation Environments</strong> are available
 <a href="tools.html">commercially and free of charge</a>, such as
-CATIA Systems, Dymola, LMS AMESim, JModelica.org, MapleSim, MWorks, OpenModelica, SimulationX, and Wolfram SystemModeler.
+CATIA Systems, Dymola, JModelica.org, LMS AMESim, MapleSim, Modelon Impact, MWorks, OpenModelica, SimulationX, and Wolfram SystemModeler.
 Modelica models can be imported conveniently into Simulink using export features of Dymola, MapleSim, and SimulationX.</p>
 <p>
 <strong>Issues</strong> (bugs, improvement suggestions, etc.) to the Modelica Language Specification can be reported via the 
@@ -990,6 +990,7 @@ AMESim® is a registered trademark of LMS
 <br />CATIA® and Dymola® are registered trademarks of Dassault Systèmes.<br />
 MapleSim® is a trademark of Waterloo Maple Inc.<br />
 Modelica® is a registered trademark of the Modelica Association.<br />
+Modelon Impact® is a registered trademark of Modelon AB<br />
 SimulationX® is a registered trademark of ESI ITI GmbH.<br />
 Simulink® is a registered trademark of The Mathworks Inc.<br />
 Wolfram SystemModeler™ is a trademark of Wolfram Research Inc.</p>


### PR DESCRIPTION
Updated by Modelon: added Modelon Impact, with trademark notice. JModelica.org remains here since it is still available, just not with support from us.