### PR TITLE
Update description of 'Modelica Language' similar to specification

### DIFF
--- a/modelicalanguage.html
+++ b/modelicalanguage.html
@@ -959,8 +959,8 @@ list of addresses below as a free service. ">
         <div class="" id="parent-fieldname-text">
             <p>
 <a href="Different-views-of-Modelica.html"><img class="image-right" src="images/Modelica-Collage-250px.png/image" alt="Different Views of Modelica" /></a>
-The <strong>Modelica Language</strong> is a non-proprietary, object-oriented, equation based language to
-conveniently model complex physical systems containing, e.g., mechanical, electrical, electronic, hydraulic, thermal, control, electric power or process-oriented subcomponents. 
+The <strong>Modelica Language</strong> is a language for modeling of cyber-physical systems, supporting acausal connection of components governed by mathematical equations to facilitate modeling from first principles.
+It provides object-oriented constructs that facilitate reuse of models, and can be used conveniently for modeling complex systems containing, e.g., mechanical, electrical, electronic, magnetic, hydraulic, thermal, control, electric power or process-oriented subcomponents.
 See also, overview in
 <a href="education/educational-material/lecture-material/english/ModelicaOverview.pdf">pdf</a>, 
 <a href="education/educational-material/lecture-material/english/ModelicaOverview.ppt">ppt</a> format and


### PR DESCRIPTION
The description in the specification was recently changed:
- https://github.com/modelica/ModelicaSpecification/pull/3037

This commit aligns with the new description, just worded slightly different to preserve the old style of having 'Modelica Language' appearing with emphasis.